### PR TITLE
Add sunrise/sunset test

### DIFF
--- a/mk_sched.py
+++ b/mk_sched.py
@@ -5,6 +5,7 @@ import argparse
 import logging
 from astropy.time import Time
 from astropy.coordinates import AltAz, Angle, EarthLocation, get_sun
+from astroplan import Observer
 import astropy.units as u
 
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
@@ -44,6 +45,8 @@ def get_sunrise_sunset_lst_astroplan(obs_date):
     # Convert to LST in hours
     sunrise_lst = sunrise_utc.sidereal_time('apparent', longitude=meerkat_location.lon).hour
     sunset_lst = sunset_utc.sidereal_time('apparent', longitude=meerkat_location.lon).hour
+
+    return sunrise_lst, sunset_lst
 
 # Calculate sunrise and sunset LST hours
 def get_sunrise_sunset_lst(obs_date):
@@ -143,7 +146,7 @@ def schedule_day(unscheduled, day, script_start_datetime, setup_time, min_obs_du
     daily_time_remaining = 24
     scheduled_today = set()
     
-    sunrise, sunset = get_sunrise_sunset_lst_astroplan(script_start_datetime + timedelta(days=day - 1))
+    sunrise, sunset = get_sunrise_sunset_lst(script_start_datetime + timedelta(days=day - 1))
     
     while daily_time_remaining > setup_time and not unscheduled.empty:
         candidates = get_schedulable_candidates(

--- a/mk_sched.py
+++ b/mk_sched.py
@@ -23,6 +23,28 @@ def lst_to_hours(lst_str):
     h, m = map(int, lst_str.split(':'))
     return h + m / 60
 
+def is_nighttime(start, end, sunrise, sunset):
+    if sunrise < sunset:
+        return end <= sunrise or start >= sunset
+    else:
+        return sunrise <= start <= sunset and sunrise <= end <= sunset
+
+def get_sunrise_sunset_lst_astroplan(obs_date):
+    """Use the astroplan library for sunrise/sunset calculation"""
+    observer = Observer(location=meerkat_location)
+    time = Time(obs_date)
+    
+    # Define the horizon for sunrise/sunset
+    horizon = -0.833 * u.deg
+    
+    # astroplan finds the next rise/set time from the given time
+    sunrise_utc = observer.sun_rise_time(time, which='next', horizon=horizon)
+    sunset_utc = observer.sun_set_time(time, which='next', horizon=horizon)
+    
+    # Convert to LST in hours
+    sunrise_lst = sunrise_utc.sidereal_time('apparent', longitude=meerkat_location.lon).hour
+    sunset_lst = sunset_utc.sidereal_time('apparent', longitude=meerkat_location.lon).hour
+
 # Calculate sunrise and sunset LST hours
 def get_sunrise_sunset_lst(obs_date):
     midnight = Time(obs_date) + timedelta(days=0.5)

--- a/mk_sched.py
+++ b/mk_sched.py
@@ -143,7 +143,7 @@ def schedule_day(unscheduled, day, script_start_datetime, setup_time, min_obs_du
     daily_time_remaining = 24
     scheduled_today = set()
     
-    sunrise, sunset = get_sunrise_sunset_lst(script_start_datetime + timedelta(days=day - 1))
+    sunrise, sunset = get_sunrise_sunset_lst_astroplan(script_start_datetime + timedelta(days=day - 1))
     
     while daily_time_remaining > setup_time and not unscheduled.empty:
         candidates = get_schedulable_candidates(

--- a/tests/test_mk_sched.py
+++ b/tests/test_mk_sched.py
@@ -1,4 +1,4 @@
-from mk_sched import lst_to_hours, next_lst_zero, get_sunrise_sunset_lst, fits_constraints, get_schedulable_candidates, select_best_candidate, update_observation_duration, schedule_day
+from mk_sched import lst_to_hours, next_lst_zero, get_sunrise_sunset_lst, get_sunrise_sunset_lst_astroplan, fits_constraints, get_schedulable_candidates, select_best_candidate, update_observation_duration, schedule_day
 from unittest.mock import patch, MagicMock
 from datetime import datetime, timedelta
 import astropy.time 
@@ -19,6 +19,18 @@ def test_lst_to_hours_conversion():
     assert lst_to_hours("0:45") == 0.75; assert lst_to_hours("7:00") == 7.0
     assert lst_to_hours("09:09") == 9.15; assert lst_to_hours("23:59") == 23 + 59/60
     assert lst_to_hours("12:00") == 12.0
+
+
+def test_sunrise_sunset_functions():
+    obs_date = datetime(2024, 1, 1)
+    sr1, ss1 = get_sunrise_sunset_lst(obs_date)
+    sr2, ss2 = get_sunrise_sunset_lst_astroplan(obs_date)
+
+    for val in (sr1, ss1, sr2, ss2):
+        assert isinstance(val, (float, np.floating))
+        assert 0.0 <= (val % 24) < 24
+
+    assert abs(((sr2 - ss2) % 24)) > 0.1
 
 class TestNextLSTZero(unittest.TestCase):
     @patch('mk_sched.datetime')


### PR DESCRIPTION
## Summary
- import astroplan Observer and return result in `get_sunrise_sunset_lst_astroplan`
- use `get_sunrise_sunset_lst` inside `schedule_day`
- add regression test covering sunrise/sunset logic

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686803e524ec8330a01f4405e702112f